### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-ransac-def.R
+++ b/feedback/topdown-ransac-def.R
@@ -1,0 +1,115 @@
+#' Fit a random sample consensus (RANSAC) linear model for outlier-contaminated data
+#     Details: https://en.wikipedia.org/wiki/Random_sample_consensus
+#' input: formula: valid lm formula (univariate response only, no offsets)
+#'        data: data.frame containing the variables in formula
+#'        error_threshold: observations with absolute prediction error below
+#           this are considered for the consensus set
+#'        inlier_threshold: minimum size of consensus set
+#'        iterations: how many random draws of candidate sets to try (
+#'          defaults to half the number of observations in data)
+#'        seed: RNG seed
+#' output: list with model (best fit lm-object on consensus set),
+#'   data (modified input data (complete cases), with additional boolean variable
+#'   ".consensus_set" indicating the best set that was found)
+#' imports checkmate, future.lapply. use future::plan("multiprocess") for parallelizing.
+ransaclm <- function(formula, data, error_threshold, inlier_threshold,
+                     iterations = nrow(data) / 2, seed = NULL) {
+  checkmate::assert_class(formula, "formula")
+  checkmate::assert_class(data, "data.frame")
+  checkmate::assert_number(error_threshold, lower = 0)
+  checkmate::assert_integerish(inlier_threshold, lower = 1, upper = nrow(data) - 1)
+  checkmate::assert_count(iterations, positive = TRUE)
+  checkmate::assert_int(seed, null.ok = TRUE, lower = 1)
+
+  if (!is.null(seed)) set.seed(as.integer(seed))
+
+  model_all <- try(lm(formula, data), silent = TRUE)
+  if (inherits(model_all, "try-error")) {
+    stop("Could not fit model on the supplied data, `lm` exited with error:\n",
+         model_all)
+  }
+  # multivariate response not allowed, easiest way to check is to disallow
+  #   matrix-coefficients
+  if (is.matrix(coefficients(model_all))) {
+    stop("Multivariate response models are not implemented.")
+  }
+  if (!is.null(model_all[["offset"]])) {
+    stop("Models with offset are not implemented.")
+  }
+
+  # model.frame gets rid of incomplete observations in <data>
+  data_all <- model.frame(model_all)
+  design <- model.matrix(model_all)
+  response <- model.response(data_all)
+
+  # do the work:
+  candidates <- future.apply::future_replicate(
+    n = iterations,
+    expr = ransac_once(design, response, error_threshold, inlier_threshold),
+    simplify = FALSE
+  )
+  best_error <- which.min(vapply(candidates, `[[`, "error",
+                                 FUN.VALUE = numeric(1)))
+  if (!length(best_error)) {
+    warning("No RANSAC model satisfied criteria, try lower inlier or error tresholds.\n")
+    return(list(model = NULL, data = data_all))
+  }
+  best_set <- candidates[[best_error]][["set"]]
+
+  # use update.lm so return object is a real lm-object (not a list from .lm.fit)
+  best_model <- update(model_all, data = data_all[best_set, ])
+  data_all$.consensus_set <- seq_len(nrow(data_all)) %in% best_set
+  list(model = best_model, data = data_all)
+}
+
+ransac_once <- function(design, response, error_threshold, inlier_threshold) {
+  # 1. generate candidate sets
+  candidate_set <- get_candidate_set(design, response, error_threshold)
+  # 2. filter out too small candidate sets
+  keep_set <- length(candidate_set) > inlier_threshold
+  if (!keep_set) {
+    return(list(error = NA_real_, set = numeric(0)))
+  }
+  # 3. refit & return error on candidate set
+  error <- refit_candidate_set(candidate_set,
+                               design = design, response = response)
+  list(error = error, set = candidate_set)
+}
+
+# return indices of all observations which <design>%*%<coefficients> predicts well
+get_inliers <- function(coefficients, design, response, error_threshold) {
+  predictions <- design %*% coefficients
+  errors <- response - predictions
+  which(abs(errors) < error_threshold)
+}
+
+# candidate for the consensus set based on a random draw of a minimal dataset:
+get_candidate_set <- function(design, response, error_threshold) {
+  # draw row indices of candidate observations for minimal dataset
+  use <- sample(x = seq_len(nrow(design)), size = ncol(design), replace = FALSE)
+  # use .lm.fit instead of lm for better performance
+  candidate_model <- try(.lm.fit(x = design[use, ], y = response[use]))
+  if (inherits(candidate_model, "try-error") ||
+      any(is.na(candidate_model[["coefficients"]]))) {
+    warning("Model fit failed on subsample.")
+    return(numeric(0))
+  }
+  # get set of observations which this_model predicts well
+  get_inliers(candidate_model[["coefficients"]],
+              design = design, response = response,
+              error_threshold = error_threshold)
+}
+
+# get error for candidate consensus set
+refit_candidate_set <- function(candidate_set, design, response) {
+  # use .lm.fit instead of lm for better performance
+  candidate_set_model <- try(.lm.fit(
+    x = design[candidate_set, ],
+    y = response[candidate_set]
+  ))
+  if (inherits(candidate_set_model, "try-error")) {
+    warning("Model fit failed on candidate set.")
+    return(NA_real_)
+  }
+  mean(residuals(candidate_set_model)^2)
+}

--- a/feedback/topdown-ransac-sol.Rmd
+++ b/feedback/topdown-ransac-sol.Rmd
@@ -1,0 +1,188 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+
+```{r, child = "topdown-ransac-ex.Rmd"}
+```
+
+-------------
+
+## Lösung:
+
+
+Die folgenden Funktionen implementiert das gewünschte:
+
+```{r, code = readLines("topdown-ransac-def.R")}
+```
+
+S. ganz unten für eine rein sequentielle, nicht parallelisierte Implementation 
+die sich stärker an dem Pseudo-Code in Wikipedia orientiert.
+
+Parallelisierung bringt hier erst bei recht großen Datensätzen Zeitvorteile:
+
+```r
+data_big <- make_ransac_data(n_obs = 10000, n_coef = 10, inlier_fraction = 0.7)
+rbenchmark::benchmark(
+  seq = {
+    future::plan("sequential")
+    ransaclm(y ~ . - inlier, data = data_big, 
+             error_threshold = 2,  inlier_threshold = 5000)
+  },
+  par = {
+    future::plan("multicore", workers = 20)
+    ransaclm(y ~ . - inlier, data = data_big, 
+             error_threshold = 2,  inlier_threshold = 5000)
+  }
+)
+#  test replications elapsed relative user.self sys.self user.child sys.child
+#2  par          100  68.319    1.000    41.161   19.956    182.699    68.478
+#1  seq          100 143.945    2.107   143.834    0.105      0.000     0.000
+```
+
+Weitere Tests:
+```{r, ransac_test_advanced, error =TRUE,fig.width = 6, fig.height = 4}
+# immer set.seed() um Ergebnisse reproduzierbar zu machen...
+set.seed(12122)
+data_simple <- make_ransac_data(100, 1, inlier_fraction = 0.7)
+
+# inlier_threshold zu hoch --> checke warnung & erwartetes Rückgabeobjekt
+testthat::expect_warning(
+  fail_inlier <- ransaclm(y ~ . - inlier,
+                          data = data_simple, error_threshold = 2,
+                          inlier_threshold = 99, seed = 20161110
+  ))
+testthat::expect_null(fail_inlier$model)
+
+# response mit NAs
+data_simple_nay <- data_simple
+data_simple_nay$y[1:50] <- NA
+ransac_simple_nay <- ransaclm(y ~ . - inlier,
+  data = data_simple_nay, error_threshold = 2,
+  inlier_threshold = 25, seed = 20161110
+)
+validate_ransac(ransac_simple_nay)
+
+# kovariable mit NAs
+data_simple_nax <- data_simple
+data_simple_nax$x[51:100] <- NA
+ransac_simple_nax <- ransaclm(y ~ . - inlier,
+  data = data_simple_nax, error_threshold = 2,
+  inlier_threshold = 25, seed = 20161110
+)
+validate_ransac(ransac_simple_nax)
+
+# multivariat
+set.seed(121221)
+data_multi <- make_ransac_data(500, 3, inlier_fraction = 0.9)
+
+ransac_multi <- ransaclm(y ~ . - inlier,
+  data = data_multi, error_threshold = 1,
+  inlier_threshold = 420, seed = 20161111
+)
+validate_ransac(ransac_multi, plot = FALSE)
+
+# multivariat mit interaktion
+ransac_multi <- ransaclm(y ~ x.1 * x.2 * x.3 - inlier,
+  data = data_multi, error_threshold = 2,
+  inlier_threshold = 400, seed = 20161110
+)
+validate_ransac(ransac_multi, plot = FALSE)
+# --> Modell fehlspezifiziert, dementsprechend schlechte Schätzung
+#     aber outlier-Identifikation noch ok
+
+# factor variable (with true coefficients 0)
+data_factor <- cbind(data_simple, x_factor = gl(4, 25))
+ransac_factor <- ransaclm(y ~ . - inlier,
+  data = data_factor, error_threshold = 2,
+  inlier_threshold = 50, seed = 20161110
+)
+validate_ransac(ransac_factor, plot = FALSE)
+
+# no outliers
+set.seed(12122)
+data_inliers <- data.frame(y = 1:100 + rnorm(100), x = 1:100, inlier = TRUE)
+ransac_inliers <- ransaclm(y ~ . - inlier,
+  data = data_inliers, error_threshold = 3,
+  inlier_threshold = 95, seed = 20161111
+)
+validate_ransac(ransac_inliers, plot = TRUE)
+```
+
+Hinweis: Durch die Formelnotation mit "`- inlier`" bleibt -- in meiner Implementation, zumindest -- die ursprünglich angelegte `inlier`-Variable, welche die wahren *inlier* identifiziert, im Datensatz des Rückgabeobjekts erhalten so dass wir mit `validate_ransac` eine Kreuztabelle der wahren und entdeckten Inlier/Outlier erzeugen können. Wenn `inlier` nicht in der Formel vorkäme würde diese Spalte nicht von `model.frame(model_all)` zurückgeliefert werden.
+
+Alternative, sequentielle Implementation:
+```{r, ransac-def-seq, eval = FALSE}
+#' Fit a random sample consensus (RANSAC) linear model for outlier-contaminated data
+#     Details: https://en.wikipedia.org/wiki/Random_sample_consensus
+#' input: formula: valid lm formula (univariate response only, no offsets)
+#'        data: data.frame containing the variables in formula
+#'        error_threshold: observations with prediction error below this are part of the
+#'          consensus set
+#'        inlier_threshold: minimum size of consensus set
+#'        iterations: how many random draws of candidate sets to try (
+#'          defaults to half the number of observations in data)
+#'        seed: RNG seed
+#' output: list with model (best fit lm-object on consensus set),
+#'   data (modified input data (complete cases), with additional boolean variable
+#'   ".consensus_set" indicating the best set that was found)
+ransaclm <- function(formula, data, error_threshold, inlier_threshold,
+                     iterations = nrow(data) / 2, seed = NULL) {
+  checkmate::assert_class(formula, "formula")
+  checkmate::assert_class(data, "data.frame")
+  checkmate::assert_number(error_threshold, lower = 0)
+  checkmate::assert_integerish(inlier_threshold, lower = 1, upper = nrow(data) - 1)
+  checkmate::assert_count(iterations, positive = TRUE)
+  checkmate::assert_int(seed, null.ok = TRUE, lower = 1)
+
+  if (!is.null(seed)) set.seed(as.integer(seed))
+
+  model_all <- try(lm(formula, data), silent = TRUE)
+  if (inherits(model_all, "try-error")) {
+    stop(
+      "Could not fit specified model on the supplied data, lm exited with error:\n",
+      model_all
+    )
+  }
+  # multivariate response models not allowed, easiest way to check is to disallow
+  #   matrix-coefficients
+  if (is.matrix(coefficients(model_all))) {
+    stop("Multivariate response models are not implemented.")
+  }
+  if (!is.null(model_all$offset)) {
+    stop("Models with offset are not implemented.")
+  }
+
+  # model.frame etc gets rid of incomplete observations in <data>
+  data_all <- model.frame(model_all)
+  design <- model.matrix(model_all)
+  response <- model.response(data_all)
+
+  # initialize with infinite error so we always start iterating
+  best_error <- Inf
+  best_set <- best_model <- NULL
+
+  for (i in seq_len(iterations)) {
+    candidate_set <- get_candidate_set(design, response, error_threshold)
+    if (length(candidate_set) < inlier_threshold) {
+      next
+    }  
+    candidate_error <- refit_consensus_set(candidate_set,
+      design = design,
+      response = response
+    )
+    if (candidate_error < best_error) {
+      best_error <- candidate_error
+      best_set <- candidate_set
+    }
+  }
+  if (is.null(best_set)) {
+    warning("No RANSAC model satisfied criteria, decrease inlier or error tresholds.\n")
+    return(list(model = NULL, data = data_all))
+  }
+  # add consensus_set variable to cleaned input data, then return model & modified data
+  best_model <- update(model_all, data = data_all[best_set, ])
+  data_all$.consensus_set <- 1:nrow(data_all) %in% best_set
+  list(model = best_model, data = data_all)
+}
+```


### PR DESCRIPTION
@marquach 

hmmm. da haben sie sich jetzt ehrlich gesagt nicht mit ruhm bekleckert.... 
wenn das die benotete hausaufgabe wäre würden sie damit fürchte ich nicht bestehen, dafür sind hier zu viele richtig
harte Bugs drin.

--------------------------------------------------------

- Ich hoffe sie haben die a) wenigstens für sich bearbeitet und nicht einfach drauflos gecodet...

- Code-Organisation: bittebitte gewöhnen Sie sich unbedingt ab einfach jeglichen code vogelwild unsortiert in ein gemeinsames übellanges chaotisches file zu schmeißen -- MINDESTENS getrennt in 3 separate files gehören die funktionsdefinitionen, die informellen code beispiele , und die formellen unit tests mit testthat. 
besser wäre es auch noch die funktionsdefinitionen sinnvoll nach themen getrennt in verschiedene files zu speichern. aussagekräftig und eindeutig benamte files, deren inhalt jeweils auf eine bildschirmseite passt, wären optimal.

- Styleguide: falls sie die Hausaufgabe machen wollen dann benutzen sie bitte checklist, lintr o.ä., ich würde ihnen hier für die fehlende funktions-doku und schlechte formatierung punkte abziehen.

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L3
https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L267
 JEDE top level funktion braucht dokumentation: was macht die funktion? was sind die inputs? was ist der output? undokumentierter code ist mist, gewöhnen sie sich das ab.  
sorry für den unfreundlichen kommentar, aber das regt mich tatsächlich auf und ich finde beim x-ten übungsblatt könnten sie diese sehr einfache und einleuchtende grundregel mal langsam verinnerlicht haben. wenn sie die a) bearbeitet haben/hätten, dann müssten sie genau das ja eh aufgeschrieben haben bevor sie den code ausarbeiten.

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L6 kommentieren sie "warum?"&"wie?" an komplizierten stellen, die schwierig zu schreiben waren, nicht "was?" an völlig offensichtlichen stellen.... 

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L10-L13
gut dass sie sich in dieses dickicht der furchtbaren `terms` funktionen getraut haben. das ist hier so aber alles sehr zerbrechlich und eher umständlich.
   - selbst im einfachsten fall muss es `number_parameters <- length(used_variables) + attributes_formula$intercept` sein (**BUG**  :face_with_head_bandage:)
    - sowas wie `y ~ poly(x, 3)` würde ihnen hier sowohl falsche parameterzahl (1 statt 4) als auch für indizierung von `data` unbrauchbare `used_variables`  geben ("poly(x, 3)" ist keine spalte in data....)  
wesentlich direkter, robuster gegenüber ausnahmen&besonderheiten und einfacher bekommt man diese informationen mMn aus model.frame, model.matrix, model.response, vgl Musterlösung. (`terms` ist furchtbar.)
   
- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L18 macht sinn nur die spalten zu prüfen die relevant sind, gut so, aber das müssen sie  halt auch konsequent durchziehen, nicht so wie hier:
https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L38  (**BUG**  :face_with_head_bandage:)  einfachste möglichkeit sowas zu vermeiden: *inputs homogenisieren* -- in ihrem fall hieße das sie schmeißen halt die irrelevanten spalten aus data raus und rechnen dann nur noch mit dem relevanten datensatz weiter, dann müssen sie so details nicht im kopf behalten. in meiner lösung mach ich das eben über model.frame usw.

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L18 nachdem sie in der folge keine anstrengungen unternehmen um mit NAs in data umzugehen, müssen sie dann halt hier auch prüfen *dass* keine NAs in den daten sind. 
besser wäre es via `model.frame` oder `complete.cases` NAs halt rauszuschmeißen.
beides nicht zu tun ist ein **BUG**  :face_with_head_bandage:
(aber: gut dass sie hier wenigstens explizit faktor-variablen ausschließen, auch wenn ich denke dass man das schon auch hätte hinkriegen können....)  

-  ganz bitterböse **BUGs**  :face_with_head_bandage: was sie hier implementieren ist NICHT der ransac algorithmus wie er in Wikipedia beschrieben ist:
   1.  es fehlt der entscheidende schritt, in jeder replikation das modell auf dem consensus set nochmal zu fitten (s. Musterlösung: `refit_consensus_set`)' und den fehler auf diesem consensus set zu speichern.
   2.  https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L69  das "beste" modell wird nicht nach der größe des consensus set, sondern nach dem fehler des auf dem consensus set angepassten modells ausgewählt.
   3. diese (undokumentierten) `early_exit` und `early_exit_proportion` argumente haben sie frei erfunden, das kommt in RANSAC halt einfach nicht vor.... y u no read instructions? :crying_cat_face:  
   4. https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L79-L80  auch dieser schritt ist nicht teil des RANSAC algorithmus
folgerichtig performt das was sie hier implementiert haben auch sauschlecht, selbst auf dem super simplen standardbsp haben sie, wenn ich das  mit unterschiedlichen seeds laufen lasse, immer > 15 fehlklassifizierte beobachtungen (korrekte variante gibt < 5) und  mies geschätzte koeffizienten.
   
- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L47 bemerkung zum stil: ein vorteil von dem top down programming stil ist dass der code lesbarer wird, weil er aus einer folge von  funktionsaufrufen besteht und jede der funktionen im besten fall so benamt ist dass direkt klar ist was in der funktion passiert. 
wenn sie jetzt trotzdem zwischen den funktionsaufrufen so zeilen wie diese hier mit langweiligen, irrelevanten housekeeping aufgaben haben macht das den gewünschten effekt ein bißchen zunichte.  
also: der befehl hier hätte halt auch noch in `get_maybe_model` reingehört, top-level wollen wir solche details eben möglichst nicht sehen.

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L52-L54  naja..... wenn das kein `good_fit` ist brauchen wir's auch nicht abspeichern, und könnten das einfacher gestalten indem wir dann hier halt zur nächsten iteration gehen: `if(!good_fit) next` 

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L42 https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L61 wozu & warum? nicht gefragt, nicht in der spezifikation, keine relevante info -- KIS, guter code ist möglichst klar und kurz.

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L56  KIS - warum denn hier so sinnlose verrenkungen um diese liste zu benamen? benutzen sie doch in der folge nirgends, user sehen das auch nicht, kann weg.

-  https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L63 styleguide -- 80 gottverdammte zeichen und keines mehr!

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L68-L86 das hätte dann halt auch in eine unterfunktion eingekapselt gehört....

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L72 nej -- ungünstig. return & warning zu mischen ist ne schlechte idee, das returniert dann den string dieser warning. 
funktionen die je nach input total unterschiedliche outputs produzieren können sind mist, weil man dann downstream immer mühsam fallunterscheidungen implementieren muss bevor man mit dem output der funktion weiterarbeiten kann. 
es ist außerdem halt hier nicht nach spezifikation in der angabe, die funktion soll *immer* eine liste mit einträgen model und data retournieren, mit model = NULL falls der algo versagt hat -- das ist also auch ein **BUG**
```r
 if (length(best) == 0) {
    warning( "No best model found. Adjust thresholds.")
    return(list(model = NULL, data = data))
  }
 ``` 
- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L78
https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L98
`lm` kann schiefgehen, also braucht das hier ein `try`' und  entsprechende nachverarbeitung, vgl musterlösung

- https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L78 aua, ganz böser **BUG**  -- sie brauchen `formula = formula`, nicht `y  ~ . -inlier`. so funktioniert das halt exakt NUR auf den bsp-datensätzen und sonst nirgends.

 

 - https://github.com/fort-w2021/ransac-ex-marquach/blob/55bdc2af28f7cfe193976dbc1f0445e4dea6d620/topdown-ransac-ex-sol.R#L305  **BUG** -- parallel tut das nur mit `%dopar%`, mit `%do%` bleibt's sequentiell.... :face_with_head_bandage: 
 - wenn ich das laufenlasse bekomme ich außerdem
```
Error in { : 
  task 1 failed - "could not find function "get_hypothetical_inliers"" 
```
 weil ihre funktion eben `get_hypothetical_inliers_rows` heißt.... :roll_eyes: **BUG**
 lassen sie den code halt bitte wenigstens laufen bevor sie abgeben, das müsste ihnen sonst ja aufgefallen sein....

-  bei `expect_error`, `expect_warning`,  `expect_message` besser immer auch prüfen ob die *erwartete* meldung ausgegeben wird, nicht nur ob *irgendwas* ausgegeben wird. 
- schade dass sie bei ihren tests nicht an die in der praxis häufigste komplikation -- NAs --  gedacht haben...